### PR TITLE
XML Schema updates

### DIFF
--- a/lib/xml-schema/xml-schema-model-adapter.ts
+++ b/lib/xml-schema/xml-schema-model-adapter.ts
@@ -54,9 +54,21 @@ class XmlSchemaAdapter {
     return {
       "targetNamespace": null,
       "elements": roots
-        .map(iri => this.classMap[iri])
+        .map(this.getClass, this)
         .map(this.classToElement, this),
     };
+  }
+
+  getClass(
+    iri: string
+  ): StructureModelClass {
+    const cls = this.classMap[iri];
+    if (cls == null) {
+      throw new Error(
+        `Class ${iri} is not defined in the model.`
+      );
+    }
+    return cls;
   }
 
   classToElement(
@@ -134,7 +146,7 @@ class XmlSchemaAdapter {
   ): StructureModelType {
     if (
       dataType.isAssociation() &&
-      this.classMap[dataType.psmClassIri].isCodelist
+      this.getClass(dataType.psmClassIri).isCodelist
     ) {
       return anyUriType;
     }
@@ -165,7 +177,7 @@ class XmlSchemaAdapter {
         "mixed": false,
         "xsType": "choice",
         "contents": dataTypes
-          .map(dataType => this.classMap[dataType.psmClassIri])
+          .map(dataType => this.getClass(dataType.psmClassIri))
           .map(classData => this.classToComplexContent(classData))
       },
     };

--- a/lib/xml-schema/xml-schema-model-adapter.ts
+++ b/lib/xml-schema/xml-schema-model-adapter.ts
@@ -15,7 +15,6 @@ import {
   XmlSchemaSimpleType,
   XmlSchemaType,
 } from "./xml-schema-model";
-import {OFN} from "../well-known";
 
 export function objectModelToXmlSchema(schema: StructureModel): XmlSchema {
   const adapter = new XmlSchemaAdapter(schema.classes);
@@ -49,7 +48,7 @@ class XmlSchemaAdapter {
   }
   
   public fromRoots(
-      roots: string[],
+    roots: string[],
   ): XmlSchema {
     return {
       "targetNamespace": null,
@@ -60,12 +59,12 @@ class XmlSchemaAdapter {
   }
 
   getClass(
-    iri: string
+    iri: string,
   ): StructureModelClass {
     const cls = this.classMap[iri];
     if (cls == null) {
       throw new Error(
-        `Class ${iri} is not defined in the model.`
+        `Class ${iri} is not defined in the model.`,
       );
     }
     return cls;
@@ -90,7 +89,7 @@ class XmlSchemaAdapter {
       "mixed": false,
       "xsType": "sequence",
       "contents": classData.properties.map(
-        this.propertyToComplexContent, this
+        this.propertyToComplexContent, this,
       ),
     };
   }
@@ -113,7 +112,7 @@ class XmlSchemaAdapter {
     let dataTypes = propertyData.dataTypes;
     if (dataTypes.length === 0) {
       throw new Error(
-        `Property ${propertyData.psmIri} has no specified types.`
+        `Property ${propertyData.psmIri} has no specified types.`,
       );
     }
     // Treat codelists as URIs
@@ -122,10 +121,10 @@ class XmlSchemaAdapter {
     // for all types in the property range.
     const result =
     this.propertyToElementCheckType(
-        propertyData,
-        dataTypes,
-        type => type.isAssociation(),
-        this.classPropertyToComplexType)
+      propertyData,
+      dataTypes,
+      type => type.isAssociation(),
+      this.classPropertyToComplexType)
       ??
       this.propertyToElementCheckType(
         propertyData,
@@ -142,7 +141,7 @@ class XmlSchemaAdapter {
   }
 
   replaceCodelistWithUri(
-    dataType: StructureModelType
+    dataType: StructureModelType,
   ): StructureModelType {
     if (
       dataType.isAssociation() &&
@@ -178,7 +177,7 @@ class XmlSchemaAdapter {
         "xsType": "choice",
         "contents": dataTypes
           .map(dataType => this.getClass(dataType.psmClassIri))
-          .map(classData => this.classToComplexContent(classData))
+          .map(classData => this.classToComplexContent(classData)),
       },
     };
   }

--- a/lib/xml-schema/xml-schema-writer.ts
+++ b/lib/xml-schema/xml-schema-writer.ts
@@ -139,7 +139,11 @@ async function writeComplexContent(
   parentContent: XmlSchemaComplexContent | null, allowCollapse: boolean,
   writer: XmlWriter,
 ): Promise<void> {
-  if (allowCollapse && definition.contents.length === 1) {
+  const contents = definition.contents;
+  if (
+    contents.length === 1 &&
+    (allowCollapse || xmlSchemaComplexContentIsType(contents[0]))
+  ) {
     await writeComplexTypes(definition, writer);
   } else {
     await writer.writeElementBegin("xs", definition.xsType);


### PR DESCRIPTION
* Codelists are treated as a datatype `xsd:anyURI` for the time being.
* A single `xs:choice` around a single `xs:sequence` is not generated.
* Adapter is now a class to capture the `ClassMap`.
* Undefined class (PSM IRI not found) throws an error.